### PR TITLE
fix: listbydate 的 unit_d -> unit_id

### DIFF
--- a/webdata/controllers/ApiController.php
+++ b/webdata/controllers/ApiController.php
@@ -369,8 +369,8 @@ class ApiController extends Pix_Controller
             $record['unit_id'] = $record['oid'];
             unset($record['oid']);
             $record['unit_name'] = $unit_oids[$record['unit_id']];
-            $record['unit_api_url'] = $this->base . '/api/listbyunit?unit_id=' . urlencode($record['unit_d']);
-            $record['tender_api_url'] = $this->base . '/api/tender?unit_id=' . urlencode($record['unit_d']) . '&job_number=' . urlencode($record['job_number']);
+            $record['unit_api_url'] = $this->base . '/api/listbyunit?unit_id=' . urlencode($record['unit_id']);
+            $record['tender_api_url'] = $this->base . '/api/tender?unit_id=' . urlencode($record['unit_id']) . '&job_number=' . urlencode($record['job_number']);
             $record['unit_url'] = '/index/unit/' . urlencode($record['unit_id']);
             $record['url'] = $entity->link();
             $result->records[] = $record;


### PR DESCRIPTION
在 https://pcc.g0v.ronny.tw/api/listbydate?date=20230922 這個網址的任一筆，其 tender_api_url 的 unit_id 誤植為 unit_d, 已修正。